### PR TITLE
Revert "bump to 2.3.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.elasticsearch.plugin.elasticfence</groupId>
     <artifactId>elasticfence</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 <!--     <packaging>pom</packaging> -->
     <description>Elasticsearch http basic auth and IP ACL plugin</description>

--- a/src/main/resources/plugin-metadata/plugin-descriptor.properties
+++ b/src/main/resources/plugin-metadata/plugin-descriptor.properties
@@ -34,7 +34,7 @@
 description=HTTP Basic User Auth and IP ACL
 #
 # 'version': plugin's version
-version=2.3.1
+version=2.2.0
 #
 # 'name': the plugin name
 name=elasticfence
@@ -60,7 +60,7 @@ classname=org.elasticsearch.plugin.elasticfence.ElasticfencePlugin
 java.version=1.7
 #
 # 'elasticsearch.version' version of elasticsearch compiled against
-elasticsearch.version=2.3.1
+elasticsearch.version=2.2.1
 #
 ### deprecated elements for jvm plugins :
 #


### PR DESCRIPTION
Reverts elasticfence/elasticsearch-http-user-auth#4

Change moved to 2.3.x branch for backwards compatibility
