### PR TITLE
[squid:S2293] The operator ("<>") should be used.

### DIFF
--- a/src/main/java/org/elasticsearch/plugin/elasticfence/parser/RequestParser.java
+++ b/src/main/java/org/elasticsearch/plugin/elasticfence/parser/RequestParser.java
@@ -64,7 +64,7 @@ public class RequestParser {
         boolean allowExplicitIndex = settings.getAsBoolean("rest.action.multi.allow_explicit_index", true);
         BytesReference data = RestActions.getRestContent(request);
 
-    	List<String> indices = new ArrayList<String>();
+    	List<String> indices = new ArrayList<>();
         XContent xContent = XContentFactory.xContent(data);
         int from = 0;
         int length = data.length();
@@ -129,7 +129,7 @@ public class RequestParser {
 
     public List<String> getIndicesFromMgetRequestBody() throws Exception {
         boolean allowExplicitIndex = settings.getAsBoolean("rest.action.multi.allow_explicit_index", true);
-        List<String> indices = new ArrayList<String>();
+        List<String> indices = new ArrayList<>();
         BytesReference data = RestActions.getRestContent(request);
         try (XContentParser parser = XContentFactory.xContent(data).createParser(data)) {
             XContentParser.Token token;
@@ -151,7 +151,7 @@ public class RequestParser {
     private List<String> parseDocuments(XContentParser parser, @Nullable String defaultIndex, boolean allowExplicitIndex) throws IOException {
         String currentFieldName = null;
         XContentParser.Token token;
-        List<String> indices = new ArrayList<String>();
+        List<String> indices = new ArrayList<>();
         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
             if (token != XContentParser.Token.START_OBJECT) {
                 throw new IllegalArgumentException("docs array element should include an object");
@@ -185,7 +185,7 @@ public class RequestParser {
 	}
 	
     private List<String> parseMsearchRequestBody(BytesReference data, boolean allowExplicitIndex) throws Exception {
-    	List<String> indexList = new ArrayList<String>();
+    	List<String> indexList = new ArrayList<>();
         XContent xContent = XContentFactory.xContent(data);
         int from = 0;
         int length = data.length();

--- a/src/test/java/org/elasticsearch/plugin/priv/data/AuthUserTest.java
+++ b/src/test/java/org/elasticsearch/plugin/priv/data/AuthUserTest.java
@@ -18,7 +18,7 @@ public class AuthUserTest {
 		UserAuthenticator.reloadUserDataCache(null);
 		UserAuthenticator userAuth ;
 		
-		List<UserData> userDataList = new ArrayList<UserData>();
+		List<UserData> userDataList = new ArrayList<>();
 
 		userDataList.add(UserData.restoreFromESData("test_admin", UserData.encPassword("test_password"), "/"));
 		UserAuthenticator.reloadUserDataCache(userDataList);
@@ -39,7 +39,7 @@ public class AuthUserTest {
 		assertFalse(userAuth.execAuth("/*"));
 		assertFalse(userAuth.execAuth("/test_index"));
 
-		userDataList = new ArrayList<UserData>();
+		userDataList = new ArrayList<>();
 		userDataList.add(UserData.restoreFromESData("test_admin", UserData.encPassword("test_password"), "/test_index"));
 		UserAuthenticator.reloadUserDataCache(userDataList);
 		userAuth = new UserAuthenticator("test_admin", "test_password");
@@ -63,7 +63,7 @@ public class AuthUserTest {
 		assertFalse(userAuth.execAuth("/test_index"));
 		assertFalse(userAuth.execAuth("/test_index1"));
 
-		userDataList = new ArrayList<UserData>();
+		userDataList = new ArrayList<>();
 		userDataList.add(UserData.restoreFromESData("test_admin", UserData.encPassword("test_password"), "/test_index*"));
 		UserAuthenticator.reloadUserDataCache(userDataList);
 		userAuth = new UserAuthenticator("test_admin", "test_password");
@@ -121,7 +121,7 @@ public class AuthUserTest {
 		assertFalse(userAuth.execAuth("/test_*index"));
 		assertFalse(userAuth.execAuth("/*test_index"));
 
-		userDataList = new ArrayList<UserData>();
+		userDataList = new ArrayList<>();
 		userDataList.add(UserData.restoreFromESData("test_admin", UserData.encPassword("test_password"), "/test_*index"));
 		UserAuthenticator.reloadUserDataCache(userDataList);
 		userAuth = new UserAuthenticator("test_admin", "test_password");
@@ -146,7 +146,7 @@ public class AuthUserTest {
 		assertFalse(userAuth.execAuth("/test_*index"));
 		assertFalse(userAuth.execAuth("/*test_index"));
 
-		userDataList = new ArrayList<UserData>();
+		userDataList = new ArrayList<>();
 		userDataList.add(UserData.restoreFromESData("test_admin", UserData.encPassword("test_password"), "/*test_index"));
 		UserAuthenticator.reloadUserDataCache(userDataList);
 		userAuth = new UserAuthenticator("test_admin", "test_password");
@@ -171,7 +171,7 @@ public class AuthUserTest {
 		assertFalse(userAuth.execAuth("/test_*index"));
 		assertFalse(userAuth.execAuth("/*test_index"));
 
-		userDataList = new ArrayList<UserData>();
+		userDataList = new ArrayList<>();
 		userDataList.add(UserData.restoreFromESData("test_admin", UserData.encPassword("test_password"), "/test_*index*"));
 		UserAuthenticator.reloadUserDataCache(userDataList);
 		userAuth = new UserAuthenticator("test_admin", "test_password");
@@ -204,7 +204,7 @@ public class AuthUserTest {
 		assertFalse(userAuth.execAuth("/*test_index*"));
 		assertFalse(userAuth.execAuth("/*test_*index*"));
 
-		userDataList = new ArrayList<UserData>();
+		userDataList = new ArrayList<>();
 		userDataList.add(UserData.restoreFromESData("test_admin", UserData.encPassword("test_password"), "/*test_*index"));
 		UserAuthenticator.reloadUserDataCache(userDataList);
 		userAuth = new UserAuthenticator("test_admin", "test_password");
@@ -237,7 +237,7 @@ public class AuthUserTest {
 		assertFalse(userAuth.execAuth("/*test_index*"));
 		assertFalse(userAuth.execAuth("/*test_*index*"));
 
-		userDataList = new ArrayList<UserData>();
+		userDataList = new ArrayList<>();
 		userDataList.add(UserData.restoreFromESData("test_admin", UserData.encPassword("test_password"), "/*test_index*"));
 		UserAuthenticator.reloadUserDataCache(userDataList);
 		userAuth = new UserAuthenticator("test_admin", "test_password");
@@ -270,7 +270,7 @@ public class AuthUserTest {
 		assertFalse(userAuth.execAuth("/*test_index*"));
 		assertFalse(userAuth.execAuth("/*test_*index*"));
 
-		userDataList = new ArrayList<UserData>();
+		userDataList = new ArrayList<>();
 		userDataList.add(UserData.restoreFromESData("test_admin", UserData.encPassword("test_password"), "/*test_*index*"));
 		UserAuthenticator.reloadUserDataCache(userDataList);
 		userAuth = new UserAuthenticator("test_admin", "test_password");
@@ -311,7 +311,7 @@ public class AuthUserTest {
 		UserAuthenticator.reloadUserDataCache(null);
 		UserAuthenticator userAuth;
 		
-		List<UserData> userDataList = new ArrayList<UserData>();
+		List<UserData> userDataList = new ArrayList<>();
 
 		userAuth = new UserAuthenticator("root", "root_password");
 		assertTrue(userAuth.execAuth("/"));
@@ -332,7 +332,7 @@ public class AuthUserTest {
 		assertTrue(userAuth.execAuth("/*test_index*"));
 		assertTrue(userAuth.execAuth("/*test_*index*"));
 
-		userDataList = new ArrayList<UserData>();
+		userDataList = new ArrayList<>();
 		userDataList.add(UserData.restoreFromESData("test_admin", UserData.encPassword("test_password"), "/"));
 		UserAuthenticator.reloadUserDataCache(userDataList);
 		userAuth = new UserAuthenticator("test_admin", "test_password");
@@ -352,7 +352,7 @@ public class AuthUserTest {
 		assertFalse(userAuth.execAuth("/*"));
 		assertFalse(userAuth.execAuth("/test_index"));
 
-		userDataList = new ArrayList<UserData>();
+		userDataList = new ArrayList<>();
 		userDataList.add(UserData.restoreFromESData("test_admin", UserData.encPassword("test_password"), "/test_index"));
 		UserAuthenticator.reloadUserDataCache(userDataList);
 		userAuth = new UserAuthenticator("test_admin", "test_password");
@@ -376,7 +376,7 @@ public class AuthUserTest {
 		assertFalse(userAuth.execAuth("/test_index"));
 		assertFalse(userAuth.execAuth("/test_index1"));
 
-		userDataList = new ArrayList<UserData>();
+		userDataList = new ArrayList<>();
 		userDataList.add(UserData.restoreFromESData("test_admin", UserData.encPassword("test_password"), "/test_index*"));
 		UserAuthenticator.reloadUserDataCache(userDataList);
 		userAuth = new UserAuthenticator("test_admin", "test_password");
@@ -434,7 +434,7 @@ public class AuthUserTest {
 		assertFalse(userAuth.execAuth("/test_*index"));
 		assertFalse(userAuth.execAuth("/*test_index"));
 
-		userDataList = new ArrayList<UserData>();
+		userDataList = new ArrayList<>();
 		userDataList.add(UserData.restoreFromESData("test_admin", UserData.encPassword("test_password"), "/test_*index"));
 		UserAuthenticator.reloadUserDataCache(userDataList);
 		userAuth = new UserAuthenticator("test_admin", "test_password");
@@ -459,7 +459,7 @@ public class AuthUserTest {
 		assertFalse(userAuth.execAuth("/test_*index"));
 		assertFalse(userAuth.execAuth("/*test_index"));
 
-		userDataList = new ArrayList<UserData>();
+		userDataList = new ArrayList<>();
 		userDataList.add(UserData.restoreFromESData("test_admin", UserData.encPassword("test_password"), "/*test_index"));
 		UserAuthenticator.reloadUserDataCache(userDataList);
 		userAuth = new UserAuthenticator("test_admin", "test_password");
@@ -484,7 +484,7 @@ public class AuthUserTest {
 		assertFalse(userAuth.execAuth("/test_*index"));
 		assertFalse(userAuth.execAuth("/*test_index"));
 
-		userDataList = new ArrayList<UserData>();
+		userDataList = new ArrayList<>();
 		userDataList.add(UserData.restoreFromESData("test_admin", UserData.encPassword("test_password"), "/test_*index*"));
 		UserAuthenticator.reloadUserDataCache(userDataList);
 		userAuth = new UserAuthenticator("test_admin", "test_password");
@@ -517,7 +517,7 @@ public class AuthUserTest {
 		assertFalse(userAuth.execAuth("/*test_index*"));
 		assertFalse(userAuth.execAuth("/*test_*index*"));
 
-		userDataList = new ArrayList<UserData>();
+		userDataList = new ArrayList<>();
 		userDataList.add(UserData.restoreFromESData("test_admin", UserData.encPassword("test_password"), "/*test_*index"));
 		UserAuthenticator.reloadUserDataCache(userDataList);
 		userAuth = new UserAuthenticator("test_admin", "test_password");
@@ -558,7 +558,7 @@ public class AuthUserTest {
 		assertFalse(userAuth.execAuth("/*test_index*"));
 		assertFalse(userAuth.execAuth("/*test_*index*"));
 
-		userDataList = new ArrayList<UserData>();
+		userDataList = new ArrayList<>();
 		userDataList.add(UserData.restoreFromESData("test_admin", UserData.encPassword("test_password"), "/*test_index*"));
 		UserAuthenticator.reloadUserDataCache(userDataList);
 		userAuth = new UserAuthenticator("test_admin", "test_password");
@@ -595,7 +595,7 @@ public class AuthUserTest {
 		assertFalse(userAuth.execAuth("/*test_index*"));
 		assertFalse(userAuth.execAuth("/*test_*index*"));
 
-		userDataList = new ArrayList<UserData>();
+		userDataList = new ArrayList<>();
 		userDataList.add(UserData.restoreFromESData("test_admin", UserData.encPassword("test_password"), "/*test_*index*"));
 		UserAuthenticator.reloadUserDataCache(userDataList);
 		userAuth = new UserAuthenticator("test_admin", "test_password");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2293 - “The diamond operator ("<>") should be used ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293

Please let me know if you have any questions.
Ayman Abdelghany.
