### PR TITLE
[squid:S1125] Literal boolean values should not be used in condition expressions

### DIFF
--- a/src/main/java/org/elasticsearch/plugin/elasticfence/UserAuthenticator.java
+++ b/src/main/java/org/elasticsearch/plugin/elasticfence/UserAuthenticator.java
@@ -91,7 +91,7 @@ public class UserAuthenticator {
 		}
 		
 		// reject if indices contains the empty index ("/") and apiName is not empty
-		if (indices.contains("/") && apiName.equals("") == false) {
+		if (indices.contains("/") && !apiName.equals("")) {
 			return false;
 		}
 		
@@ -111,7 +111,7 @@ public class UserAuthenticator {
 					break;
 				}
 			}
-			if (passed == false) {
+			if (!passed) {
 				return false;
 			}
 		}

--- a/src/main/java/org/elasticsearch/plugin/elasticfence/parser/RequestParser.java
+++ b/src/main/java/org/elasticsearch/plugin/elasticfence/parser/RequestParser.java
@@ -37,7 +37,7 @@ public class RequestParser {
 	}
 	
 	private void initialize() {
-		if (isInitialized == false) {
+		if (!isInitialized) {
 			normalizedPath = normalizePath(request.path());
 			indexInPath    = extractIndexFromPath(normalizedPath);
 			indicesInPath  = extractIndicesFromPath(normalizedPath);
@@ -105,7 +105,7 @@ public class RequestParser {
                                     throw new IllegalArgumentException("explicit index in bulk is not allowed");
                                 }
                                 index = "/" + parser.text();
-                                if (indices.contains(index) == false) {
+                                if (!indices.contains(index)) {
                                 	indices.add(index);
                                 }
                             }
@@ -113,7 +113,7 @@ public class RequestParser {
                     }
                 }
 
-                if ("delete".equals(action) == false) {
+                if (!"delete".equals(action)) {
                     nextMarker = findNextMarker(marker, from, data, length);
                     if (nextMarker == -1) {
                         break;
@@ -166,7 +166,7 @@ public class RequestParser {
                             throw new IllegalArgumentException("explicit index in multi get is not allowed");
                         }
                         index = "/" + parser.text();
-                        if (indices.contains(index) == false) {
+                        if (!indices.contains(index)) {
                         	indices.add(index);
                         }
                     }
@@ -215,7 +215,7 @@ public class RequestParser {
                             }
                             for (String index : nodeStringArrayValue(value)) {
                             	index = "/" + index;
-                            	if (indexList.contains(index) == false) {
+                            	if (!indexList.contains(index)) {
                             		indexList.add(index);
                             	}
                             }
@@ -263,7 +263,7 @@ public class RequestParser {
 		if (indexStr.indexOf(',') >= 0) {
 			for (String index : indexStr.split(",")) {
 				index = "/" + index;
-				if (indices.contains(index) == false) {
+				if (!indices.contains(index)) {
 					indices.add(index);
 				}
 			}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1125- “Literal boolean values should not be used in condition expressions”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1125

Please let me know if you have any questions.
Ayman Abdelghany.
