### PR TITLE
[squid:S1126] Return of boolean expressions should not be wrapped into an "if-then-else" statement

### DIFF
--- a/src/main/java/org/elasticsearch/plugin/elasticfence/IPAuthenticator.java
+++ b/src/main/java/org/elasticsearch/plugin/elasticfence/IPAuthenticator.java
@@ -22,11 +22,7 @@ public class IPAuthenticator {
 
         public boolean isWhitelisted(String ip) {
 		if (whitelist == null) return false;
-                if ( Arrays.asList(whitelist).contains(ip) ) {
-                        return true;
-                } else {
-                        return false;
-                }
+                return Arrays.asList(whitelist).contains(ip);
         }
         public static void setBlacklist(String[] blacklist) {
                 if (blacklist == null) blacklist = new String[]{};
@@ -35,11 +31,7 @@ public class IPAuthenticator {
 
         public boolean isBlacklisted(String ip) {
 		if (blacklist == null) return false;
-                if ( Arrays.asList(blacklist).contains(ip) ) {
-                        return true;
-                } else {
-                        return false;
-                }
+                return Arrays.asList(blacklist).contains(ip);
         }
 }
 

--- a/src/main/java/org/elasticsearch/plugin/elasticfence/UserAuthenticator.java
+++ b/src/main/java/org/elasticsearch/plugin/elasticfence/UserAuthenticator.java
@@ -32,11 +32,7 @@ public class UserAuthenticator {
 		}
 	}
 	public boolean isValidUser() {
-		if (user == null) {
-			return false;
-		} else {
-			return true;
-		}
+		return user != null;
 	}
 
 	public boolean isAccessibleIndices(RequestParser parser) {
@@ -246,11 +242,7 @@ public class UserAuthenticator {
 		// processing regex conditions
 		if (index.contains("*")) {
 			// just compare if both filter and index include "*" character, too. 
-			if (index.equals(filter)) {
-				return true;
-			} else {
-				return false;
-			}
+			return index.equals(filter);
 		} else {
 			// only filter contains "*" char
 			String regexStr = "";
@@ -272,11 +264,7 @@ public class UserAuthenticator {
 			else regexStr += "$";
 			Pattern p = Pattern.compile(regexStr);
 			Matcher m = p.matcher(index);
-			if (m.find()){
-				return true;
-			} else {
-				return false;
-			}
+			return m.find();
 		}
 	}
 	

--- a/src/main/java/org/elasticsearch/plugin/elasticfence/data/UserData.java
+++ b/src/main/java/org/elasticsearch/plugin/elasticfence/data/UserData.java
@@ -107,11 +107,7 @@ public class UserData {
 	}
 	
 	public boolean isValidPassword(String rawPassword) {
-		if (encPassword.equals(encPassword(rawPassword))) {
-			return true;
-		} else {
-			return false;
-		}
+		return encPassword.equals(encPassword(rawPassword));
 	}
 	
 	public String toJSON() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1126 - “Return of boolean expressions should not be wrapped into an "if-then-else" statement”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1126

Please let me know if you have any questions.
Ayman Abdelghany.
