### PR TITLE
[squid:S2293] The operator ("<>") should be used.

### DIFF
--- a/src/main/java/org/elasticsearch/plugin/elasticfence/parser/RequestParser.java
+++ b/src/main/java/org/elasticsearch/plugin/elasticfence/parser/RequestParser.java
@@ -64,7 +64,7 @@ public class RequestParser {
         boolean allowExplicitIndex = settings.getAsBoolean("rest.action.multi.allow_explicit_index", true);
         BytesReference data = RestActions.getRestContent(request);
 
-    	List<String> indices = new ArrayList<String>();
+    	List<String> indices = new ArrayList<>();
         XContent xContent = XContentFactory.xContent(data);
         int from = 0;
         int length = data.length();
@@ -129,7 +129,7 @@ public class RequestParser {
 
     public List<String> getIndicesFromMgetRequestBody() throws Exception {
         boolean allowExplicitIndex = settings.getAsBoolean("rest.action.multi.allow_explicit_index", true);
-        List<String> indices = new ArrayList<String>();
+        List<String> indices = new ArrayList<>();
         BytesReference data = RestActions.getRestContent(request);
         try (XContentParser parser = XContentFactory.xContent(data).createParser(data)) {
             XContentParser.Token token;
@@ -151,7 +151,7 @@ public class RequestParser {
     private List<String> parseDocuments(XContentParser parser, @Nullable String defaultIndex, boolean allowExplicitIndex) throws IOException {
         String currentFieldName = null;
         XContentParser.Token token;
-        List<String> indices = new ArrayList<String>();
+        List<String> indices = new ArrayList<>();
         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
             if (token != XContentParser.Token.START_OBJECT) {
                 throw new IllegalArgumentException("docs array element should include an object");
@@ -185,7 +185,7 @@ public class RequestParser {
 	}
 	
     private List<String> parseMsearchRequestBody(BytesReference data, boolean allowExplicitIndex) throws Exception {
-    	List<String> indexList = new ArrayList<String>();
+    	List<String> indexList = new ArrayList<>();
         XContent xContent = XContentFactory.xContent(data);
         int from = 0;
         int length = data.length();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2293 - “The diamond operator ("<>") should be used ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293

Please let me know if you have any questions.
Ayman Abdelghany.
