### PR TITLE
[squid:S1132] Strings literals should be placed on the left side when checking for equality

### DIFF
--- a/src/main/java/org/elasticsearch/plugin/elasticfence/AuthRestHandler.java
+++ b/src/main/java/org/elasticsearch/plugin/elasticfence/AuthRestHandler.java
@@ -35,7 +35,7 @@ public class AuthRestHandler extends BaseRestHandler {
 	        channel.sendResponse(new BytesRestResponse(SERVICE_UNAVAILABLE, "http user auth initializing..."));
 	        return ;
         }
-		if (mode.equals("list")) {
+		if ("list".equals(mode)) {
 	        try {
 		        String userListJSON = userDataBridge.listUser();
 		        channel.sendResponse(new BytesRestResponse(OK, userListJSON));
@@ -45,7 +45,7 @@ public class AuthRestHandler extends BaseRestHandler {
 	        }
 	        return ;
 		}
-		if (mode.equals("adduser")) {
+		if ("adduser".equals(mode)) {
 			String userName = request.param("username");
 			String password = request.param("password");
 	        try {
@@ -62,7 +62,7 @@ public class AuthRestHandler extends BaseRestHandler {
 		        return ;
 	        }
 		}
-		if (mode.equals("addindex")) {
+		if ("addindex".equals(mode)) {
 			String userName  = request.param("username");
 			String indexName = request.param("index");
 
@@ -81,7 +81,7 @@ public class AuthRestHandler extends BaseRestHandler {
 	        return;
 		}
 
-		if (mode.equals("updateindex")) {
+		if ("updateindex".equals(mode)) {
 			String userName  = request.param("username");
 			String indexName = request.param("index");
 
@@ -100,7 +100,7 @@ public class AuthRestHandler extends BaseRestHandler {
 	        return;
 		}
 		
-		if (mode.equals("passwd")) {
+		if ("passwd".equals(mode)) {
 			String userName = request.param("username");
 			String oldPassword = request.param("old_password");
 			String newPassword = request.param("new_password");
@@ -114,7 +114,7 @@ public class AuthRestHandler extends BaseRestHandler {
 	        return;
 		}
 
-		if (mode.equals("deleteuser")) {
+		if ("deleteuser".equals(mode)) {
 			String userName  = request.param("username");
 	        
 	        boolean res = userDataBridge.deleteUser(userName);

--- a/src/main/java/org/elasticsearch/plugin/elasticfence/ElasticfencePlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/elasticfence/ElasticfencePlugin.java
@@ -32,11 +32,11 @@ public class ElasticfencePlugin extends Plugin {
     public void onModule(RestModule module) {
     	String isPluginDisabled = getSettingString("disabled");
         
-    	if (isPluginDisabled != null && isPluginDisabled.equals("true")) {
+    	if (isPluginDisabled != null && "true".equals(isPluginDisabled)) {
             EFLogger.warn("Elasticfence plugin is disabled");
     	} else {
         	String rootPassword = getSettingString("root.password");
-        	if (rootPassword != null && !rootPassword.equals("")) {
+        	if (rootPassword != null && !"".equals(rootPassword)) {
         		UserAuthenticator.setRootPassword(rootPassword);
         		UserAuthenticator.loadRootUserDataCacheOnStart();
         	}

--- a/src/main/java/org/elasticsearch/plugin/elasticfence/UserAuthenticator.java
+++ b/src/main/java/org/elasticsearch/plugin/elasticfence/UserAuthenticator.java
@@ -40,7 +40,7 @@ public class UserAuthenticator {
 			return false;
 		}
 
-		if (user.getUsername().equals("root")) {
+		if ("root".equals(user.getUsername())) {
 			return true;
 		}
 		
@@ -87,7 +87,7 @@ public class UserAuthenticator {
 		}
 		
 		// reject if indices contains the empty index ("/") and apiName is not empty
-		if (indices.contains("/") && !apiName.equals("")) {
+		if (indices.contains("/") && !"".equals(apiName)) {
 			return false;
 		}
 		
@@ -122,7 +122,7 @@ public class UserAuthenticator {
 	 */
 	private boolean isKibanaRequest(String requestPath) {
 		String index = normalizeUrlPath(requestPath);
-		if (requestPath.equals("/") || requestPath.equals("/_nodes") || index.equals("/.kibana") || requestPath.equals("/_cluster/health/.kibana")) {
+		if ("/".equals(requestPath) || "/_nodes".equals(requestPath) || "/.kibana".equals(index) || "/_cluster/health/.kibana".equals(requestPath)) {
 			return true;
 		}
 		
@@ -154,12 +154,12 @@ public class UserAuthenticator {
 			return false;
 		}
 		
-		if (user.getUsername().equals("root")) {
+		if ("root".equals(user.getUsername())) {
 			return true;
 		}
 		
 		// the all matching path /* is only accessible by root. 
-		if (path.equals("/*")) {
+		if ("/*".equals(path)) {
 			return false;
 		}
 		
@@ -228,15 +228,15 @@ public class UserAuthenticator {
 			return true;
 		
 		// processing a special case in advance
-		if (index.equals("") || filter.equals("")) {
-			if (filter.equals("") && index.equals("")) {
+		if ("".equals(index) || "".equals(filter)) {
+			if ("".equals(filter) && "".equals(index)) {
 				return true;
 			}
 			return false;
 		}
 		
 		if (!filter.contains("*")) {
-			if (index.equals("*")) {
+			if ("*".equals(index)) {
 				return true;
 			} else {
 				// compare as strings
@@ -256,7 +256,7 @@ public class UserAuthenticator {
 			String[] splitStrArr = filter.split("\\*");
 			for (int i = 0; i < splitStrArr.length; i++) {
 				if (i < splitStrArr.length - 1) {
-					if (splitStrArr[i].equals("")) {
+					if ("".equals(splitStrArr[i])) {
 						regexStr += ".*?";
 					} else {
 						regexStr += Pattern.quote(splitStrArr[i]) + ".*?";
@@ -285,7 +285,7 @@ public class UserAuthenticator {
 	 * @return
 	 */
 	private static String normalizeUrlPath(String path) {
-		if (path.equals("") || path.charAt(0) != '/') {
+		if ("".equals(path) || path.charAt(0) != '/') {
 			path = "/" + path;
 		}
 		try {
@@ -301,18 +301,18 @@ public class UserAuthenticator {
 		}
 		
 		// this case won't occur, but just in case
-		if (path.equals("")) 
+		if ("".equals(path)) 
 			return "/";
 		
 		// single slash is special path
-		if (path.equals("/")) 
+		if ("/".equals(path)) 
 			return "/";
 		
 		String[] pathInfo = path.split("/");
 		String index = "";
 		for (String str : pathInfo) {
 			// first none-empty string is index name
-			if (str.equals("")) 
+			if ("".equals(str)) 
 				continue;
 			index = str;
 			break;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1132 - “Strings literals should be placed on the left side when checking for equality”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1132

Please let me know if you have any questions.
Ayman Abdelghany.
